### PR TITLE
getCompatibleVersion not matching

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -64,7 +64,7 @@ class Plugin extends Base
 
     public function getCompatibleVersion()
     {
-        return '1.2.3';
+        return '>=1.2.3';
     }
 
 }


### PR DESCRIPTION
Needs to be the same as https://github.com/kanboard/website/blob/master/plugins.json.
Please push a new release or update the current one w/ the fixed version.